### PR TITLE
Fix mysqli2 parent class.

### DIFF
--- a/src/dbFacile/mysqli2.php
+++ b/src/dbFacile/mysqli2.php
@@ -6,7 +6,7 @@ namespace dbFacile;
  * Originally reported by mbutomax on Github
  * Reported here: https://github.com/alanszlosek/dbFacile/pull/8
  */
-class mysqli2 extends \dbFacile\base
+class mysqli2 extends \dbFacile\mysqli
 {
     protected function _fetchAll($result)
     {


### PR DESCRIPTION
The mysqli2 class must extends the mysqli class and not the base class.

If this is not done, PHP will reject any attempt to use the mysqli2 class due to unimplemented abstract functions.
